### PR TITLE
Inicializar scaffold de `finanzas-app`: DB, esquema, backend inicial y docs

### DIFF
--- a/finanzas-app/.env.example
+++ b/finanzas-app/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_DB=finanzas_db
+POSTGRES_USER=finanzas
+POSTGRES_PASSWORD=finanzas_dev
+POSTGRES_PORT=5432

--- a/finanzas-app/README.md
+++ b/finanzas-app/README.md
@@ -1,0 +1,83 @@
+# App de Finanzas Personales (ARS/USD)
+
+Base inicial del proyecto para gestionar finanzas personales por mes, con foco en pesos, soporte de ingresos en dólares, gastos fijos, consumos, ahorro y cotización diaria.
+
+## Stack objetivo
+
+- Backend: NestJS + TypeScript + Prisma
+- Frontend: Next.js + React + Tailwind
+- Base de datos: PostgreSQL
+- Infra local: Docker Compose
+
+## Alcance de esta base
+
+- Infra local de PostgreSQL lista para iniciar.
+- Esquema SQL inicial en español.
+- Documentación del modelo de datos y endpoints v1.
+
+## Levantar base de datos local
+
+1. Copiar variables de entorno:
+
+```bash
+cp .env.example .env
+```
+
+2. Iniciar PostgreSQL:
+
+```bash
+docker compose up -d
+```
+
+> El esquema `bd/01_esquema_inicial.sql` se aplica automáticamente en el primer arranque del contenedor.
+
+3. Aplicar esquema inicial:
+
+```bash
+docker compose exec -T postgres psql -U finanzas -d finanzas_db < bd/01_esquema_inicial.sql
+```
+
+Este paso solo hace falta si querés reaplicar el esquema manualmente.
+
+## Conectar DBeaver
+
+Podés usar esta guía rápida con los datos de conexión locales:
+
+- `Host`: `localhost`
+- `Puerto`: `5432`
+- `Base`: `finanzas_db`
+- `Usuario`: `finanzas`
+- `Contraseña`: `finanzas_dev`
+
+Detalle completo: `docs/conexion_dbeaver.md`.
+
+## Reiniciar base desde cero
+
+Si necesitás borrar todo y volver a crear la base limpia:
+
+```bash
+./scripts/reset_bd.sh
+```
+
+## Backend inicial
+
+Se agregó un backend mínimo en `backend/` para verificar entorno:
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+Endpoint de salud:
+
+```bash
+curl http://localhost:3000/salud
+```
+
+## Próximos pasos sugeridos
+
+1. Inicializar backend NestJS en `backend/`.
+2. Traducir esquema SQL a Prisma schema.
+3. Implementar autenticación + hogares compartidos.
+4. Exponer endpoints de movimientos, categorías, etiquetas y cotizaciones.

--- a/finanzas-app/backend/package.json
+++ b/finanzas-app/backend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "finanzas-backend",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Backend inicial para app de finanzas personales",
+  "scripts": {
+    "dev": "node src/main.js",
+    "start": "node src/main.js"
+  }
+}

--- a/finanzas-app/backend/src/main.js
+++ b/finanzas-app/backend/src/main.js
@@ -1,0 +1,18 @@
+const http = require('http');
+
+const port = Number(process.env.PORT || 3000);
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/salud') {
+    res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({ ok: true, servicio: 'finanzas-backend', version: '0.1.0' }));
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify({ mensaje: 'Backend inicial en construcción' }));
+});
+
+server.listen(port, () => {
+  console.log(`finanzas-backend escuchando en http://localhost:${port}`);
+});

--- a/finanzas-app/bd/01_esquema_inicial.sql
+++ b/finanzas-app/bd/01_esquema_inicial.sql
@@ -1,0 +1,143 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS hogares (
+  id BIGSERIAL PRIMARY KEY,
+  nombre VARCHAR(120) NOT NULL,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS usuarios (
+  id BIGSERIAL PRIMARY KEY,
+  correo VARCHAR(160) NOT NULL UNIQUE,
+  clave_hash VARCHAR(255) NOT NULL,
+  nombre VARCHAR(120) NOT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS hogares_usuarios (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  usuario_id BIGINT NOT NULL REFERENCES usuarios(id),
+  rol VARCHAR(30) NOT NULL DEFAULT 'miembro',
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hogar_id, usuario_id)
+);
+
+CREATE TABLE IF NOT EXISTS cuentas (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  nombre VARCHAR(120) NOT NULL,
+  tipo VARCHAR(40) NOT NULL,
+  moneda_base VARCHAR(3) NOT NULL CHECK (moneda_base IN ('ARS', 'USD')),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tipos_movimiento (
+  id SMALLSERIAL PRIMARY KEY,
+  codigo VARCHAR(30) NOT NULL UNIQUE,
+  nombre VARCHAR(80) NOT NULL UNIQUE
+);
+
+INSERT INTO tipos_movimiento (codigo, nombre)
+VALUES
+  ('ingreso', 'Ingreso'),
+  ('egreso', 'Egreso'),
+  ('ahorro', 'Ahorro')
+ON CONFLICT (codigo) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS categorias (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  nombre VARCHAR(80) NOT NULL,
+  tipo_movimiento_id SMALLINT NOT NULL REFERENCES tipos_movimiento(id),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hogar_id, nombre, tipo_movimiento_id)
+);
+
+CREATE TABLE IF NOT EXISTS etiquetas (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  nombre VARCHAR(60) NOT NULL,
+  creada_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hogar_id, nombre)
+);
+
+CREATE TABLE IF NOT EXISTS cotizaciones_dolar (
+  id BIGSERIAL PRIMARY KEY,
+  fecha DATE NOT NULL,
+  fuente VARCHAR(40) NOT NULL,
+  compra NUMERIC(14,4),
+  venta NUMERIC(14,4) NOT NULL,
+  moneda_origen VARCHAR(3) NOT NULL DEFAULT 'USD',
+  moneda_destino VARCHAR(3) NOT NULL DEFAULT 'ARS',
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (fecha, fuente)
+);
+
+CREATE TABLE IF NOT EXISTS movimientos (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  cuenta_id BIGINT REFERENCES cuentas(id),
+  tipo_movimiento_id SMALLINT NOT NULL REFERENCES tipos_movimiento(id),
+  categoria_id BIGINT REFERENCES categorias(id),
+  fecha DATE NOT NULL,
+  descripcion TEXT,
+  moneda_original VARCHAR(3) NOT NULL CHECK (moneda_original IN ('ARS', 'USD')),
+  monto_original NUMERIC(14,2) NOT NULL CHECK (monto_original > 0),
+  cotizacion_aplicada NUMERIC(14,4),
+  monto_ars NUMERIC(14,2) NOT NULL CHECK (monto_ars > 0),
+  creado_por_usuario_id BIGINT NOT NULL REFERENCES usuarios(id),
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS movimientos_etiquetas (
+  movimiento_id BIGINT NOT NULL REFERENCES movimientos(id) ON DELETE CASCADE,
+  etiqueta_id BIGINT NOT NULL REFERENCES etiquetas(id) ON DELETE CASCADE,
+  PRIMARY KEY (movimiento_id, etiqueta_id)
+);
+
+CREATE TABLE IF NOT EXISTS gastos_fijos (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  categoria_id BIGINT NOT NULL REFERENCES categorias(id),
+  descripcion VARCHAR(160) NOT NULL,
+  moneda VARCHAR(3) NOT NULL CHECK (moneda IN ('ARS', 'USD')),
+  monto_base NUMERIC(14,2) NOT NULL CHECK (monto_base > 0),
+  dia_vencimiento SMALLINT CHECK (dia_vencimiento BETWEEN 1 AND 31),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  actualizado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ajustes_gastos_fijos (
+  id BIGSERIAL PRIMARY KEY,
+  gasto_fijo_id BIGINT NOT NULL REFERENCES gastos_fijos(id) ON DELETE CASCADE,
+  fecha_aplicacion DATE NOT NULL,
+  tipo_ajuste VARCHAR(20) NOT NULL CHECK (tipo_ajuste IN ('porcentaje', 'monto_fijo')),
+  valor NUMERIC(14,4) NOT NULL,
+  nota VARCHAR(255),
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS valores_ipc (
+  id BIGSERIAL PRIMARY KEY,
+  periodo VARCHAR(7) NOT NULL,
+  valor NUMERIC(10,4) NOT NULL,
+  fuente VARCHAR(80) NOT NULL,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (periodo, fuente)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movimientos_hogar_fecha
+  ON movimientos (hogar_id, fecha);
+
+CREATE INDEX IF NOT EXISTS idx_movimientos_tipo_fecha
+  ON movimientos (tipo_movimiento_id, fecha);
+
+CREATE INDEX IF NOT EXISTS idx_cotizaciones_fecha_fuente
+  ON cotizaciones_dolar (fecha, fuente);
+
+COMMIT;

--- a/finanzas-app/docker-compose.yml
+++ b/finanzas-app/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: finanzas_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-finanzas_db}
+      POSTGRES_USER: ${POSTGRES_USER:-finanzas}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-finanzas_dev}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./bd/01_esquema_inicial.sql:/docker-entrypoint-initdb.d/01_esquema_inicial.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-finanzas} -d ${POSTGRES_DB:-finanzas_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/finanzas-app/docs/api_v1.md
+++ b/finanzas-app/docs/api_v1.md
@@ -1,0 +1,41 @@
+# API v1 (borrador)
+
+## Autenticación y hogar
+
+- `POST /auth/registro`
+- `POST /auth/login`
+- `POST /hogares`
+- `POST /hogares/:id/invitaciones`
+
+## Catálogos
+
+- `GET /tipos-movimiento`
+- `GET /categorias`
+- `POST /categorias`
+- `GET /etiquetas`
+- `POST /etiquetas`
+
+## Movimientos
+
+- `GET /movimientos?desde=YYYY-MM-DD&hasta=YYYY-MM-DD`
+- `POST /movimientos`
+- `PATCH /movimientos/:id`
+- `DELETE /movimientos/:id`
+
+## Gastos fijos
+
+- `GET /gastos-fijos`
+- `POST /gastos-fijos`
+- `POST /gastos-fijos/:id/ajustes`
+
+## Cotizaciones e IPC
+
+- `GET /cotizaciones?fecha=YYYY-MM-DD`
+- `POST /cotizaciones/sincronizar` (astropay/mep)
+- `GET /ipc?periodo=YYYY-MM`
+- `POST /ipc/sincronizar`
+
+## Dashboard
+
+- `GET /dashboard/mes-actual`
+- `GET /dashboard/ultimo-mes-cerrado`

--- a/finanzas-app/docs/conexion_dbeaver.md
+++ b/finanzas-app/docs/conexion_dbeaver.md
@@ -1,0 +1,25 @@
+# Conexión a PostgreSQL desde DBeaver
+
+## Datos de conexión (desarrollo local)
+
+- Host: `localhost`
+- Puerto: `5432` (o el valor de `POSTGRES_PORT` en `.env`)
+- Base de datos: `finanzas_db`
+- Usuario: `finanzas`
+- Contraseña: `finanzas_dev`
+
+> Si cambiaste los valores del `.env`, usá esos mismos en DBeaver.
+
+## Pasos en DBeaver
+
+1. **Database > New Database Connection**.
+2. Elegí **PostgreSQL**.
+3. Completá host, puerto, base, usuario y contraseña.
+4. Click en **Test Connection**.
+5. Guardá la conexión.
+
+## Problemas comunes
+
+- **Connection refused**: verificar que el contenedor esté arriba (`docker compose ps`).
+- **Password authentication failed**: revisar usuario/clave en `.env`.
+- **No se crean tablas**: si el volumen ya existía, el script de init no corre de nuevo. En ese caso ejecutar el SQL manualmente o resetear la BD.

--- a/finanzas-app/docs/modelo_datos.md
+++ b/finanzas-app/docs/modelo_datos.md
@@ -1,0 +1,23 @@
+# Modelo de datos v1
+
+## Objetivos
+
+- Multiusuario compartido por hogar.
+- Registro de ingresos, egresos y ahorro.
+- Cotización histórica USD/ARS por fuente.
+- Reportes en pesos (`monto_ars`) sin perder moneda original.
+
+## Reglas importantes
+
+1. Todo movimiento guarda moneda original y su equivalente en ARS.
+2. Si un movimiento está en ARS, `cotizacion_aplicada` puede quedar nula.
+3. Las etiquetas son dinámicas por hogar.
+4. Categorías simples (sin subcategorías en v1).
+5. Aumentos de gastos fijos solo manuales en v1.
+
+## Fuentes de cotización
+
+- Prioridad: AstroPay.
+- Fallback: MEP.
+
+Se guardan ambas si están disponibles para comparar comportamiento histórico.

--- a/finanzas-app/scripts/reset_bd.sh
+++ b/finanzas-app/scripts/reset_bd.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resetea la base local eliminando volumen y recreando contenedor.
+# ADVERTENCIA: borra todos los datos locales de PostgreSQL.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+echo "[1/3] Deteniendo servicios..."
+docker compose down
+
+echo "[2/3] Eliminando volumen postgres_data..."
+docker volume rm finanzas-app_postgres_data >/dev/null 2>&1 || true
+
+echo "[3/3] Iniciando PostgreSQL limpio..."
+docker compose up -d
+
+echo "Base reiniciada. El esquema se aplica automáticamente al primer arranque."


### PR DESCRIPTION
### Motivation
- Proveer una base inicial para la app de finanzas personales con infraestructura local y esquema de datos listos para desarrollo. 
- Permitir levantar PostgreSQL por Docker y tener un backend mínimo para pruebas de entorno. 
- Documentar el modelo de datos y los endpoints v1 para guiar próximas implementaciones.

### Description
- Agregado de configuración y ejemplos de entorno con `.env.example` y `docker-compose.yml` que monta `bd/01_esquema_inicial.sql` en `docker-entrypoint-initdb.d` para inicializar la BD. 
- Creación del esquema SQL `bd/01_esquema_inicial.sql` con tablas, restricciones, índices e inserts iniciales para `tipos_movimiento`. 
- Backend mínimo en `backend/` con `package.json` y `src/main.js` que expone un endpoint de salud `GET /salud`. 
- Documentación y utilidades: `README.md`, `docs/api_v1.md`, `docs/modelo_datos.md`, `docs/conexion_dbeaver.md` y script `scripts/reset_bd.sh` para reiniciar la base local.

### Testing
- No se incluyeron ni ejecutaron pruebas automatizadas en este cambio (no hay CI ni test suite configurados en el scaffold).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacd15207c83288b2f7048cd9541c9)