### PR TITLE
Initialize finanzas-app: backend (Express/pg), frontend (React/Vite), DB schema, infra and docs

### DIFF
--- a/finanzas-app/.env.example
+++ b/finanzas-app/.env.example
@@ -1,0 +1,5 @@
+POSTGRES_DB=finanzas_db
+POSTGRES_USER=finanzas
+POSTGRES_PASSWORD=finanzas_dev
+POSTGRES_PORT=5432
+POSTGRES_HOST=localhost

--- a/finanzas-app/README.md
+++ b/finanzas-app/README.md
@@ -1,0 +1,320 @@
+# App de Finanzas Personales (ARS/USD)
+
+Base inicial del proyecto para gestionar finanzas personales por mes, con foco en pesos, soporte de ingresos en dólares, gastos fijos, consumos, ahorro y cotización diaria.
+
+## Stack objetivo
+
+- Backend: NestJS + TypeScript + Prisma (pendiente en próximos pasos)
+- Frontend: Next.js + React + Tailwind (pendiente en próximos pasos)
+- Base de datos: PostgreSQL
+- Infra local: Docker Compose
+
+## Si no sabés si clonar o hacer pull
+
+### Caso A: **No tenés el repo en tu PC**
+
+1. Abrí terminal (PowerShell, CMD o Git Bash).
+2. Cloná el repositorio:
+
+```bash
+git clone <URL_DE_TU_REPO>
+cd ProbandoJoaquin/finanzas-app
+```
+
+### Caso B: **Ya tenés el repo en tu PC**
+
+```bash
+cd <carpeta-donde-tenes-el-repo>/ProbandoJoaquin
+git pull
+cd finanzas-app
+```
+
+---
+
+## Levantar el entorno local (paso a paso)
+
+### 1) Preparar variables de entorno
+
+```bash
+cp .env.example .env
+```
+
+> En Windows PowerShell, si `cp` no funciona: `Copy-Item .env.example .env`
+
+### 2) Levantar PostgreSQL
+
+Opción recomendada (automática):
+
+```bash
+./scripts/iniciar_entorno.sh
+```
+
+Si estás en **PowerShell (Windows)** usá:
+
+```powershell
+.\scripts\iniciar_entorno.ps1
+```
+
+Opción manual:
+
+```bash
+docker compose up -d
+```
+
+### 3) Verificar estado si algo falla
+
+```bash
+./scripts/estado_entorno.sh
+```
+
+PowerShell:
+
+```powershell
+.\scripts\estado_entorno.ps1
+```
+
+### 4) Reiniciar base desde cero (si querés empezar limpio)
+
+```bash
+./scripts/reset_bd.sh
+```
+
+PowerShell:
+
+```powershell
+.\scripts\reset_bd.ps1
+```
+
+---
+
+## Conectar DBeaver
+
+Usá estos datos:
+
+- `Host`: `localhost`
+- `Puerto`: `5432`
+- `Base`: `finanzas_db`
+- `Usuario`: `finanzas`
+- `Contraseña`: `finanzas_dev`
+
+Guía completa: `docs/conexion_dbeaver.md`.
+
+---
+
+## Backend inicial
+
+Se agregó un backend inicial en `backend/` con conexión a PostgreSQL y endpoints de movimientos.
+
+```bash
+cd backend
+cp .env.example .env
+npm install
+npm run dev
+```
+
+Probar endpoint de salud:
+
+```bash
+curl http://localhost:3000/salud
+```
+
+Listar movimientos demo:
+
+```bash
+curl "http://localhost:3000/movimientos?hogar_id=1"
+```
+
+Actualizar un movimiento:
+
+```bash
+curl -X PATCH http://localhost:3000/movimientos/1 \
+  -H "Content-Type: application/json" \
+  -d '{ "descripcion": "Compra supermercado mensual" }'
+```
+
+Eliminar un movimiento:
+
+```bash
+curl -X DELETE http://localhost:3000/movimientos/1
+```
+
+Listar categorías del hogar:
+
+```bash
+curl "http://localhost:3000/categorias?hogar_id=1"
+```
+
+Crear etiqueta:
+
+```bash
+curl -X POST http://localhost:3000/etiquetas \
+  -H "Content-Type: application/json" \
+  -d '{ "hogar_id": 1, "nombre": "tarjeta" }'
+```
+
+## Frontend inicial (React + Vite)
+
+Se agregó un frontend base en `frontend/` con:
+
+- resumen de ingresos/egresos/balance,
+- alta de movimientos vía modal popup,
+- edición y eliminación de movimientos desde la tabla,
+- botones de acción con íconos (✏️ editar / 🗑️ eliminar),
+- tabla de movimientos,
+- menú lateral colapsable fijo a la izquierda,
+- visualización del ciclo actual (ej: abril 2026),
+- panel de cotización del dólar,
+- sección de gastos fijos (alta + listado),
+- confirmación de eliminación en popup propio,
+- filtro para ver/ocultar movimientos eliminados,
+- conexión a API vía `VITE_API_URL`.
+
+```bash
+cd frontend
+cp .env.example .env
+npm install
+npm run dev
+```
+
+Abrí `http://localhost:5173`.
+
+## ¿Tengo que correr siempre `npm install` y `npm run dev`?
+
+Regla práctica:
+
+- `npm install`: **solo la primera vez** (o cuando cambie `package.json`).
+- `npm run dev`: **sí, cada vez que quieras levantar** backend/frontend en modo desarrollo.
+
+Flujo diario típico:
+
+1. Levantar DB (`docker compose up -d` o script `iniciar_entorno`).
+2. Terminal 1 (`backend/`): `npm run dev`.
+3. Terminal 2 (`frontend/`): `npm run dev`.
+
+Si bajaste cambios nuevos del repo y cambió `package.json`, corré otra vez `npm install`.
+
+### Error común en frontend: "Failed to fetch"
+
+Suele pasar cuando backend no está levantado o falta reinstalar dependencias tras cambios.
+
+Checklist:
+
+1. En `backend/`: `npm install` (importante si cambió `package.json`) y `npm run dev`.
+2. Probar salud backend: `curl http://localhost:3000/salud`.
+3. En `frontend/.env` verificar `VITE_API_URL=http://localhost:3000`.
+4. Reiniciar `npm run dev` de frontend.
+
+### Flujo para levantar el proyecto cada vez (mientras seguimos metiendo cambios)
+
+1. `git pull` en tu rama local.
+2. `docker compose up -d` (o `./scripts/iniciar_entorno.ps1`).
+3. Backend (`finanzas-app/backend`):
+   - `npm install` solo si cambió `package.json`
+   - `npm run dev`
+4. Frontend (`finanzas-app/frontend`):
+   - `npm install` solo si cambió `package.json`
+   - `npm run dev`
+5. Abrir `http://localhost:5173`.
+
+Crear un movimiento demo:
+
+```bash
+curl -X POST http://localhost:3000/movimientos \
+  -H "Content-Type: application/json" \
+  -d '{
+    "hogar_id": 1,
+    "cuenta_id": 1,
+    "tipo_movimiento_id": 2,
+    "categoria_id": 2,
+    "fecha": "2026-04-12",
+    "descripcion": "Compra supermercado",
+    "moneda_original": "ARS",
+    "monto_original": 55000,
+    "monto_ars": 55000,
+    "creado_por_usuario_id": 1
+  }'
+```
+
+## Datos demo opcionales
+
+Para cargar un hogar/usuario/categorías demo y probar la API rápido:
+
+```bash
+docker compose exec -T postgres psql -U finanzas -d finanzas_db < bd/02_datos_demo.sql
+```
+
+Si ya tenías una base creada de antes, aplicá también la migración de baja lógica en movimientos:
+
+```bash
+docker compose exec -T postgres psql -U finanzas -d finanzas_db < bd/03_movimientos_soft_delete.sql
+```
+
+En PowerShell usá este formato (porque `<` da error):
+
+```powershell
+Get-Content .\bd\03_movimientos_soft_delete.sql | docker compose exec -T postgres psql -U finanzas -d finanzas_db
+```
+
+---
+
+## Qué incluye hoy este repo
+
+- Infra local de PostgreSQL lista para iniciar.
+- Esquema SQL inicial en español.
+- Documentación del modelo de datos y endpoints v1.
+- Scripts de operación local (`iniciar_entorno`, `estado_entorno`, `reset_bd`).
+
+## Próximos pasos sugeridos
+
+1. Inicializar backend NestJS real en `backend/`.
+2. Traducir esquema SQL a Prisma schema.
+3. Implementar autenticación + hogares compartidos.
+4. Exponer endpoints de movimientos, categorías, etiquetas y cotizaciones.
+
+## Resolver conflictos al abrir PR
+
+Si GitHub te marca conflictos en `.env.example`, `README.md` o docs, hacé esto en tu rama:
+
+```bash
+git fetch origin
+git checkout <tu-rama>
+git merge origin/main
+```
+
+Después resolvé conflictos en los archivos marcados, guardá, y ejecutá:
+
+```bash
+git add finanzas-app/.env.example finanzas-app/README.md finanzas-app/docs/conexion_dbeaver.md
+git commit -m "Resuelve conflictos con main"
+git push
+```
+
+Cuando subas ese push, el PR debería quedar sin conflictos.
+
+Guía extendida: `docs/resolver_conflictos_pr.md`.
+
+## ¿Dónde quedan los cambios y cómo traerlos a tu repo local?
+
+Todos los cambios de código/documentación que hago quedan en el repositorio remoto (rama de trabajo + PR).
+En tu PC local siempre hacé este flujo para traer lo último:
+
+```bash
+cd <tu-repo>/ProbandoJoaquin
+git fetch --all
+git checkout <rama-que-estas-usando>
+git pull
+```
+
+Si querés incorporar lo de una rama remota nueva:
+
+```bash
+git checkout -b mi-rama-local origin/<rama-remota>
+```
+
+Después de trabajar localmente, para subir tus cambios:
+
+```bash
+git add .
+git commit -m "mensaje"
+git push
+```

--- a/finanzas-app/backend/.env.example
+++ b/finanzas-app/backend/.env.example
@@ -1,0 +1,6 @@
+API_PORT=3000
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=finanzas_db
+DB_USER=finanzas
+DB_PASSWORD=finanzas_dev

--- a/finanzas-app/backend/package.json
+++ b/finanzas-app/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "finanzas-backend",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Backend inicial para app de finanzas personales",
+  "main": "src/main.js",
+  "scripts": {
+    "dev": "node src/main.js",
+    "start": "node src/main.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.6.1",
+    "express": "^4.21.2",
+    "pg": "^8.16.3"
+  }
+}

--- a/finanzas-app/backend/src/main.js
+++ b/finanzas-app/backend/src/main.js
@@ -1,0 +1,500 @@
+const express = require('express');
+const cors = require('cors');
+const { Pool } = require('pg');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const pool = new Pool({
+  host: process.env.DB_HOST || 'localhost',
+  port: Number(process.env.DB_PORT || 5432),
+  database: process.env.DB_NAME || 'finanzas_db',
+  user: process.env.DB_USER || 'finanzas',
+  password: process.env.DB_PASSWORD || 'finanzas_dev'
+});
+
+function parseFecha(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : value;
+}
+
+function esNumeroPositivo(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0;
+}
+
+app.get('/salud', async (_req, res) => {
+  try {
+    await pool.query('SELECT 1');
+    res.status(200).json({ ok: true, servicio: 'finanzas-backend', db: 'ok' });
+  } catch (error) {
+    res.status(500).json({ ok: false, servicio: 'finanzas-backend', db: 'error', detalle: error.message });
+  }
+});
+
+app.get('/movimientos', async (req, res) => {
+  const hogarId = Number(req.query.hogar_id);
+  const desde = parseFecha(req.query.desde);
+  const hasta = parseFecha(req.query.hasta);
+  const incluirEliminados = String(req.query.incluir_eliminados || 'false') === 'true';
+
+  if (!hogarId) {
+    return res.status(400).json({ error: 'hogar_id es obligatorio' });
+  }
+
+  if ((req.query.desde && !desde) || (req.query.hasta && !hasta)) {
+    return res.status(400).json({ error: 'desde/hasta deben tener formato YYYY-MM-DD' });
+  }
+
+  try {
+    const params = [hogarId];
+    const filtros = ['m.hogar_id = $1'];
+
+    if (!incluirEliminados) {
+      filtros.push('m.activo = true');
+    }
+
+    if (desde) {
+      params.push(desde);
+      filtros.push(`m.fecha >= $${params.length}`);
+    }
+
+    if (hasta) {
+      params.push(hasta);
+      filtros.push(`m.fecha <= $${params.length}`);
+    }
+
+    const query = `
+      SELECT
+        m.id,
+        m.fecha,
+        m.descripcion,
+        m.moneda_original,
+        m.monto_original,
+        m.cotizacion_aplicada,
+        m.monto_ars,
+        m.activo,
+        m.eliminado_en,
+        tm.codigo AS tipo_movimiento,
+        c.nombre AS categoria
+      FROM movimientos m
+      JOIN tipos_movimiento tm ON tm.id = m.tipo_movimiento_id
+      LEFT JOIN categorias c ON c.id = m.categoria_id
+      WHERE ${filtros.join(' AND ')}
+      ORDER BY m.fecha DESC, m.id DESC
+    `;
+
+    const { rows } = await pool.query(query, params);
+    return res.status(200).json({ total: rows.length, items: rows });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error consultando movimientos', detalle: error.message });
+  }
+});
+
+app.post('/movimientos', async (req, res) => {
+  const {
+    hogar_id,
+    cuenta_id,
+    tipo_movimiento_id,
+    categoria_id,
+    fecha,
+    descripcion,
+    moneda_original,
+    monto_original,
+    cotizacion_aplicada,
+    monto_ars,
+    creado_por_usuario_id
+  } = req.body;
+
+  if (!hogar_id || !tipo_movimiento_id || !fecha || !moneda_original || !monto_original || !monto_ars || !creado_por_usuario_id) {
+    return res.status(400).json({
+      error: 'Faltan campos obligatorios: hogar_id, tipo_movimiento_id, fecha, moneda_original, monto_original, monto_ars, creado_por_usuario_id'
+    });
+  }
+
+  if (!['ARS', 'USD'].includes(moneda_original)) {
+    return res.status(400).json({ error: 'moneda_original debe ser ARS o USD' });
+  }
+
+  if (!parseFecha(fecha)) {
+    return res.status(400).json({ error: 'fecha debe tener formato YYYY-MM-DD' });
+  }
+
+  if (!esNumeroPositivo(monto_original) || !esNumeroPositivo(monto_ars)) {
+    return res.status(400).json({ error: 'monto_original y monto_ars deben ser mayores a 0' });
+  }
+
+  try {
+    const query = `
+      INSERT INTO movimientos (
+        hogar_id,
+        cuenta_id,
+        tipo_movimiento_id,
+        categoria_id,
+        fecha,
+        descripcion,
+        moneda_original,
+        monto_original,
+        cotizacion_aplicada,
+        monto_ars,
+        creado_por_usuario_id
+      ) VALUES (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11
+      )
+      RETURNING id, fecha, moneda_original, monto_original, monto_ars
+    `;
+
+    const values = [
+      hogar_id,
+      cuenta_id || null,
+      tipo_movimiento_id,
+      categoria_id || null,
+      fecha,
+      descripcion || null,
+      moneda_original,
+      monto_original,
+      cotizacion_aplicada || null,
+      monto_ars,
+      creado_por_usuario_id
+    ];
+
+    const { rows } = await pool.query(query, values);
+    return res.status(201).json({ ok: true, movimiento: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error creando movimiento', detalle: error.message });
+  }
+});
+
+app.patch('/movimientos/:id', async (req, res) => {
+  const movimientoId = Number(req.params.id);
+  const { descripcion, categoria_id, cuenta_id } = req.body;
+
+  if (!movimientoId) {
+    return res.status(400).json({ error: 'id inválido' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      UPDATE movimientos
+      SET descripcion = COALESCE($1, descripcion),
+          categoria_id = COALESCE($2, categoria_id),
+          cuenta_id = COALESCE($3, cuenta_id)
+      WHERE id = $4 AND activo = true
+      RETURNING id, fecha, descripcion, categoria_id, cuenta_id, activo
+      `,
+      [descripcion ?? null, categoria_id ?? null, cuenta_id ?? null, movimientoId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Movimiento no encontrado' });
+    }
+
+    return res.status(200).json({ ok: true, movimiento: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error actualizando movimiento', detalle: error.message });
+  }
+});
+
+app.delete('/movimientos/:id', async (req, res) => {
+  const movimientoId = Number(req.params.id);
+
+  if (!movimientoId) {
+    return res.status(400).json({ error: 'id inválido' });
+  }
+
+  try {
+    const { rowCount } = await pool.query(
+      `
+      UPDATE movimientos
+      SET activo = false,
+          eliminado_en = NOW()
+      WHERE id = $1 AND activo = true
+      `,
+      [movimientoId]
+    );
+
+    if (rowCount === 0) {
+      return res.status(404).json({ error: 'Movimiento no encontrado' });
+    }
+
+    return res.status(200).json({ ok: true, eliminado_id: movimientoId });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error eliminando movimiento', detalle: error.message });
+  }
+});
+
+app.get('/categorias', async (req, res) => {
+  const hogarId = Number(req.query.hogar_id);
+
+  if (!hogarId) {
+    return res.status(400).json({ error: 'hogar_id es obligatorio' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      SELECT c.id, c.nombre, tm.codigo AS tipo_movimiento
+      FROM categorias c
+      JOIN tipos_movimiento tm ON tm.id = c.tipo_movimiento_id
+      WHERE c.hogar_id = $1 AND c.activo = true
+      ORDER BY c.nombre ASC
+      `,
+      [hogarId]
+    );
+
+    return res.status(200).json({ total: rows.length, items: rows });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error consultando categorías', detalle: error.message });
+  }
+});
+
+app.post('/categorias', async (req, res) => {
+  const { hogar_id, nombre, tipo_movimiento_id } = req.body;
+
+  if (!hogar_id || !nombre || !tipo_movimiento_id) {
+    return res.status(400).json({ error: 'hogar_id, nombre y tipo_movimiento_id son obligatorios' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      INSERT INTO categorias (hogar_id, nombre, tipo_movimiento_id)
+      VALUES ($1, $2, $3)
+      RETURNING id, hogar_id, nombre, tipo_movimiento_id
+      `,
+      [hogar_id, nombre.trim(), tipo_movimiento_id]
+    );
+
+    return res.status(201).json({ ok: true, categoria: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error creando categoría', detalle: error.message });
+  }
+});
+
+app.get('/etiquetas', async (req, res) => {
+  const hogarId = Number(req.query.hogar_id);
+
+  if (!hogarId) {
+    return res.status(400).json({ error: 'hogar_id es obligatorio' });
+  }
+
+  try {
+    const { rows } = await pool.query('SELECT id, nombre FROM etiquetas WHERE hogar_id = $1 ORDER BY nombre ASC', [hogarId]);
+    return res.status(200).json({ total: rows.length, items: rows });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error consultando etiquetas', detalle: error.message });
+  }
+});
+
+app.post('/etiquetas', async (req, res) => {
+  const { hogar_id, nombre } = req.body;
+
+  if (!hogar_id || !nombre) {
+    return res.status(400).json({ error: 'hogar_id y nombre son obligatorios' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      INSERT INTO etiquetas (hogar_id, nombre)
+      VALUES ($1, $2)
+      ON CONFLICT (hogar_id, nombre) DO UPDATE SET nombre = EXCLUDED.nombre
+      RETURNING id, hogar_id, nombre
+      `,
+      [hogar_id, nombre.trim()]
+    );
+
+    return res.status(201).json({ ok: true, etiqueta: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error creando etiqueta', detalle: error.message });
+  }
+});
+
+app.get('/dashboard/resumen', async (req, res) => {
+  const hogarId = Number(req.query.hogar_id);
+
+  if (!hogarId) {
+    return res.status(400).json({ error: 'hogar_id es obligatorio' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      SELECT
+        COALESCE(SUM(CASE WHEN tm.codigo = 'ingreso' THEN m.monto_ars END), 0) AS ingresos,
+        COALESCE(SUM(CASE WHEN tm.codigo = 'egreso' THEN m.monto_ars END), 0) AS egresos,
+        COALESCE(SUM(CASE WHEN tm.codigo = 'ahorro' THEN m.monto_ars END), 0) AS ahorros,
+        COALESCE(COUNT(m.id), 0) AS cantidad_movimientos
+      FROM movimientos m
+      JOIN tipos_movimiento tm ON tm.id = m.tipo_movimiento_id
+      WHERE m.hogar_id = $1
+      `,
+      [hogarId]
+    );
+
+    const resumen = rows[0] || { ingresos: 0, egresos: 0, ahorros: 0, cantidad_movimientos: 0 };
+    const balance = Number(resumen.ingresos) - Number(resumen.egresos);
+
+    return res.status(200).json({
+      ingresos: Number(resumen.ingresos),
+      egresos: Number(resumen.egresos),
+      ahorros: Number(resumen.ahorros),
+      balance,
+      cantidad_movimientos: Number(resumen.cantidad_movimientos)
+    });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error consultando resumen', detalle: error.message });
+  }
+});
+
+app.get('/cotizaciones', async (req, res) => {
+  const { fecha } = req.query;
+
+  try {
+    if (fecha) {
+      const { rows } = await pool.query(
+        `
+        SELECT fecha, fuente, compra, venta
+        FROM cotizaciones_dolar
+        WHERE fecha = $1
+        ORDER BY fuente ASC
+        `,
+        [fecha]
+      );
+
+      return res.status(200).json({ total: rows.length, items: rows });
+    }
+
+    const { rows } = await pool.query(
+      `
+      SELECT DISTINCT ON (fuente)
+        fecha,
+        fuente,
+        compra,
+        venta
+      FROM cotizaciones_dolar
+      ORDER BY fuente, fecha DESC
+      `
+    );
+
+    return res.status(200).json({ total: rows.length, items: rows });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error consultando cotizaciones', detalle: error.message });
+  }
+});
+
+app.post('/cotizaciones', async (req, res) => {
+  const { fecha, fuente, compra, venta } = req.body;
+
+  if (!fecha || !fuente || !venta) {
+    return res.status(400).json({ error: 'fecha, fuente y venta son obligatorios' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      INSERT INTO cotizaciones_dolar (fecha, fuente, compra, venta)
+      VALUES ($1, $2, $3, $4)
+      ON CONFLICT (fecha, fuente)
+      DO UPDATE SET compra = EXCLUDED.compra, venta = EXCLUDED.venta
+      RETURNING id, fecha, fuente, compra, venta
+      `,
+      [fecha, fuente, compra || null, venta]
+    );
+
+    return res.status(201).json({ ok: true, cotizacion: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error creando cotización', detalle: error.message });
+  }
+});
+
+app.get('/gastos-fijos', async (req, res) => {
+  const hogarId = Number(req.query.hogar_id);
+
+  if (!hogarId) {
+    return res.status(400).json({ error: 'hogar_id es obligatorio' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      SELECT gf.id, gf.descripcion, gf.moneda, gf.monto_base, gf.dia_vencimiento, c.nombre AS categoria
+      FROM gastos_fijos gf
+      JOIN categorias c ON c.id = gf.categoria_id
+      WHERE gf.hogar_id = $1 AND gf.activo = true
+      ORDER BY gf.id DESC
+      `,
+      [hogarId]
+    );
+
+    return res.status(200).json({ total: rows.length, items: rows });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error consultando gastos fijos', detalle: error.message });
+  }
+});
+
+app.post('/gastos-fijos', async (req, res) => {
+  const { hogar_id, categoria_id, descripcion, moneda, monto_base, dia_vencimiento } = req.body;
+
+  if (!hogar_id || !categoria_id || !descripcion || !moneda || !monto_base) {
+    return res.status(400).json({ error: 'hogar_id, categoria_id, descripcion, moneda y monto_base son obligatorios' });
+  }
+
+  if (!['ARS', 'USD'].includes(moneda)) {
+    return res.status(400).json({ error: 'moneda debe ser ARS o USD' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      INSERT INTO gastos_fijos (hogar_id, categoria_id, descripcion, moneda, monto_base, dia_vencimiento)
+      VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING id, hogar_id, categoria_id, descripcion, moneda, monto_base, dia_vencimiento
+      `,
+      [hogar_id, categoria_id, descripcion, moneda, monto_base, dia_vencimiento || null]
+    );
+
+    return res.status(201).json({ ok: true, gasto_fijo: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error creando gasto fijo', detalle: error.message });
+  }
+});
+
+app.post('/gastos-fijos/:id/ajustes', async (req, res) => {
+  const gastoFijoId = Number(req.params.id);
+  const { fecha_aplicacion, tipo_ajuste, valor, nota } = req.body;
+
+  if (!gastoFijoId || !fecha_aplicacion || !tipo_ajuste || !valor) {
+    return res.status(400).json({ error: 'id, fecha_aplicacion, tipo_ajuste y valor son obligatorios' });
+  }
+
+  if (!['porcentaje', 'monto_fijo'].includes(tipo_ajuste)) {
+    return res.status(400).json({ error: "tipo_ajuste debe ser 'porcentaje' o 'monto_fijo'" });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      INSERT INTO ajustes_gastos_fijos (gasto_fijo_id, fecha_aplicacion, tipo_ajuste, valor, nota)
+      VALUES ($1, $2, $3, $4, $5)
+      RETURNING id, gasto_fijo_id, fecha_aplicacion, tipo_ajuste, valor, nota
+      `,
+      [gastoFijoId, fecha_aplicacion, tipo_ajuste, valor, nota || null]
+    );
+
+    return res.status(201).json({ ok: true, ajuste: rows[0] });
+  } catch (error) {
+    return res.status(500).json({ error: 'Error creando ajuste de gasto fijo', detalle: error.message });
+  }
+});
+
+const port = Number(process.env.API_PORT || 3000);
+app.listen(port, () => {
+  console.log(`finanzas-backend escuchando en http://localhost:${port}`);
+});

--- a/finanzas-app/bd/01_esquema_inicial.sql
+++ b/finanzas-app/bd/01_esquema_inicial.sql
@@ -1,0 +1,145 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS hogares (
+  id BIGSERIAL PRIMARY KEY,
+  nombre VARCHAR(120) NOT NULL,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS usuarios (
+  id BIGSERIAL PRIMARY KEY,
+  correo VARCHAR(160) NOT NULL UNIQUE,
+  clave_hash VARCHAR(255) NOT NULL,
+  nombre VARCHAR(120) NOT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS hogares_usuarios (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  usuario_id BIGINT NOT NULL REFERENCES usuarios(id),
+  rol VARCHAR(30) NOT NULL DEFAULT 'miembro',
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hogar_id, usuario_id)
+);
+
+CREATE TABLE IF NOT EXISTS cuentas (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  nombre VARCHAR(120) NOT NULL,
+  tipo VARCHAR(40) NOT NULL,
+  moneda_base VARCHAR(3) NOT NULL CHECK (moneda_base IN ('ARS', 'USD')),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tipos_movimiento (
+  id SMALLSERIAL PRIMARY KEY,
+  codigo VARCHAR(30) NOT NULL UNIQUE,
+  nombre VARCHAR(80) NOT NULL UNIQUE
+);
+
+INSERT INTO tipos_movimiento (codigo, nombre)
+VALUES
+  ('ingreso', 'Ingreso'),
+  ('egreso', 'Egreso'),
+  ('ahorro', 'Ahorro')
+ON CONFLICT (codigo) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS categorias (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  nombre VARCHAR(80) NOT NULL,
+  tipo_movimiento_id SMALLINT NOT NULL REFERENCES tipos_movimiento(id),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hogar_id, nombre, tipo_movimiento_id)
+);
+
+CREATE TABLE IF NOT EXISTS etiquetas (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  nombre VARCHAR(60) NOT NULL,
+  creada_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hogar_id, nombre)
+);
+
+CREATE TABLE IF NOT EXISTS cotizaciones_dolar (
+  id BIGSERIAL PRIMARY KEY,
+  fecha DATE NOT NULL,
+  fuente VARCHAR(40) NOT NULL,
+  compra NUMERIC(14,4),
+  venta NUMERIC(14,4) NOT NULL,
+  moneda_origen VARCHAR(3) NOT NULL DEFAULT 'USD',
+  moneda_destino VARCHAR(3) NOT NULL DEFAULT 'ARS',
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (fecha, fuente)
+);
+
+CREATE TABLE IF NOT EXISTS movimientos (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  cuenta_id BIGINT REFERENCES cuentas(id),
+  tipo_movimiento_id SMALLINT NOT NULL REFERENCES tipos_movimiento(id),
+  categoria_id BIGINT REFERENCES categorias(id),
+  fecha DATE NOT NULL,
+  descripcion TEXT,
+  moneda_original VARCHAR(3) NOT NULL CHECK (moneda_original IN ('ARS', 'USD')),
+  monto_original NUMERIC(14,2) NOT NULL CHECK (monto_original > 0),
+  cotizacion_aplicada NUMERIC(14,4),
+  monto_ars NUMERIC(14,2) NOT NULL CHECK (monto_ars > 0),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  eliminado_en TIMESTAMPTZ,
+  creado_por_usuario_id BIGINT NOT NULL REFERENCES usuarios(id),
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS movimientos_etiquetas (
+  movimiento_id BIGINT NOT NULL REFERENCES movimientos(id) ON DELETE CASCADE,
+  etiqueta_id BIGINT NOT NULL REFERENCES etiquetas(id) ON DELETE CASCADE,
+  PRIMARY KEY (movimiento_id, etiqueta_id)
+);
+
+CREATE TABLE IF NOT EXISTS gastos_fijos (
+  id BIGSERIAL PRIMARY KEY,
+  hogar_id BIGINT NOT NULL REFERENCES hogares(id),
+  categoria_id BIGINT NOT NULL REFERENCES categorias(id),
+  descripcion VARCHAR(160) NOT NULL,
+  moneda VARCHAR(3) NOT NULL CHECK (moneda IN ('ARS', 'USD')),
+  monto_base NUMERIC(14,2) NOT NULL CHECK (monto_base > 0),
+  dia_vencimiento SMALLINT CHECK (dia_vencimiento BETWEEN 1 AND 31),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  actualizado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ajustes_gastos_fijos (
+  id BIGSERIAL PRIMARY KEY,
+  gasto_fijo_id BIGINT NOT NULL REFERENCES gastos_fijos(id) ON DELETE CASCADE,
+  fecha_aplicacion DATE NOT NULL,
+  tipo_ajuste VARCHAR(20) NOT NULL CHECK (tipo_ajuste IN ('porcentaje', 'monto_fijo')),
+  valor NUMERIC(14,4) NOT NULL,
+  nota VARCHAR(255),
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS valores_ipc (
+  id BIGSERIAL PRIMARY KEY,
+  periodo VARCHAR(7) NOT NULL,
+  valor NUMERIC(10,4) NOT NULL,
+  fuente VARCHAR(80) NOT NULL,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (periodo, fuente)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movimientos_hogar_fecha
+  ON movimientos (hogar_id, fecha);
+
+CREATE INDEX IF NOT EXISTS idx_movimientos_tipo_fecha
+  ON movimientos (tipo_movimiento_id, fecha);
+
+CREATE INDEX IF NOT EXISTS idx_cotizaciones_fecha_fuente
+  ON cotizaciones_dolar (fecha, fuente);
+
+COMMIT;

--- a/finanzas-app/bd/02_datos_demo.sql
+++ b/finanzas-app/bd/02_datos_demo.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+INSERT INTO hogares (id, nombre)
+VALUES (1, 'Hogar Demo')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO usuarios (id, correo, clave_hash, nombre)
+VALUES (1, 'demo@finanzas.local', 'demo_hash', 'Usuario Demo')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO hogares_usuarios (hogar_id, usuario_id, rol)
+VALUES (1, 1, 'admin')
+ON CONFLICT (hogar_id, usuario_id) DO NOTHING;
+
+INSERT INTO cuentas (id, hogar_id, nombre, tipo, moneda_base)
+VALUES
+  (1, 1, 'Efectivo', 'caja', 'ARS'),
+  (2, 1, 'Cuenta USD', 'banco', 'USD')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO categorias (id, hogar_id, nombre, tipo_movimiento_id)
+VALUES
+  (1, 1, 'Sueldo', 1),
+  (2, 1, 'Alimentos', 2),
+  (3, 1, 'Ahorro', 3)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO cotizaciones_dolar (fecha, fuente, compra, venta)
+VALUES
+  (CURRENT_DATE, 'mep', 1125.00, 1130.00),
+  (CURRENT_DATE, 'astropay', 1110.00, 1140.00)
+ON CONFLICT (fecha, fuente) DO NOTHING;
+
+COMMIT;

--- a/finanzas-app/bd/03_movimientos_soft_delete.sql
+++ b/finanzas-app/bd/03_movimientos_soft_delete.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE movimientos
+  ADD COLUMN IF NOT EXISTS activo BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE movimientos
+  ADD COLUMN IF NOT EXISTS eliminado_en TIMESTAMPTZ;
+
+UPDATE movimientos
+SET activo = TRUE
+WHERE activo IS NULL;
+
+COMMIT;

--- a/finanzas-app/docker-compose.yml
+++ b/finanzas-app/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: finanzas_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-finanzas_db}
+      POSTGRES_USER: ${POSTGRES_USER:-finanzas}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-finanzas_dev}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./bd/01_esquema_inicial.sql:/docker-entrypoint-initdb.d/01_esquema_inicial.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-finanzas} -d ${POSTGRES_DB:-finanzas_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/finanzas-app/docs/api_v1.md
+++ b/finanzas-app/docs/api_v1.md
@@ -1,0 +1,72 @@
+# API v1 (borrador)
+
+## Autenticación y hogar
+
+- `POST /auth/registro`
+- `POST /auth/login`
+- `POST /hogares`
+- `POST /hogares/:id/invitaciones`
+
+## Catálogos
+
+- `GET /tipos-movimiento`
+- `GET /categorias`
+- `POST /categorias`
+- `GET /etiquetas`
+- `POST /etiquetas`
+
+### Estado actual de implementación
+
+- ✅ `GET /categorias?hogar_id=1`
+- ✅ `POST /categorias`
+- ✅ `GET /etiquetas?hogar_id=1`
+- ✅ `POST /etiquetas`
+
+## Movimientos
+
+- `GET /movimientos?desde=YYYY-MM-DD&hasta=YYYY-MM-DD`
+- `POST /movimientos`
+- `PATCH /movimientos/:id`
+- `DELETE /movimientos/:id`
+
+### Estado actual de implementación
+
+- ✅ `GET /movimientos?hogar_id=1[&desde=YYYY-MM-DD&hasta=YYYY-MM-DD]`
+- ✅ `GET /movimientos?hogar_id=1&incluir_eliminados=true|false`
+- ✅ `POST /movimientos`
+- ✅ `PATCH /movimientos/:id` (actualiza descripción/categoría/cuenta)
+- ✅ `DELETE /movimientos/:id` (baja lógica)
+
+## Gastos fijos
+
+- `GET /gastos-fijos`
+- `POST /gastos-fijos`
+- `POST /gastos-fijos/:id/ajustes`
+
+### Estado actual de implementación
+
+- ✅ `GET /gastos-fijos?hogar_id=1`
+- ✅ `POST /gastos-fijos`
+- ✅ `POST /gastos-fijos/:id/ajustes`
+
+## Cotizaciones e IPC
+
+- `GET /cotizaciones?fecha=YYYY-MM-DD`
+- `POST /cotizaciones/sincronizar` (astropay/mep)
+- `GET /ipc?periodo=YYYY-MM`
+- `POST /ipc/sincronizar`
+
+### Estado actual de implementación
+
+- ✅ `GET /cotizaciones`
+- ✅ `GET /cotizaciones?fecha=YYYY-MM-DD`
+- ✅ `POST /cotizaciones` (carga manual)
+
+## Dashboard
+
+- `GET /dashboard/mes-actual`
+- `GET /dashboard/ultimo-mes-cerrado`
+
+### Estado actual de implementación
+
+- ✅ `GET /dashboard/resumen?hogar_id=1`

--- a/finanzas-app/docs/conexion_dbeaver.md
+++ b/finanzas-app/docs/conexion_dbeaver.md
@@ -1,0 +1,59 @@
+# Conexión a PostgreSQL desde DBeaver
+
+## Datos de conexión (desarrollo local)
+
+- Host: `localhost`
+- Puerto: `5432` (o el valor de `POSTGRES_PORT` en `.env`)
+- Base de datos: `finanzas_db`
+- Usuario: `finanzas`
+- Contraseña: `finanzas_dev`
+
+> Si cambiaste los valores del `.env`, usá esos mismos en DBeaver.
+
+## Pasos en DBeaver
+
+1. **Database > New Database Connection**.
+2. Elegí **PostgreSQL**.
+3. Completá host, puerto, base, usuario y contraseña.
+4. Click en **Test Connection**.
+5. Guardá la conexión.
+
+## Error: "Connection refused: getsockopt"
+
+Ese error normalmente significa que **PostgreSQL no está levantado** o que el puerto/host no coincide.
+
+### Checklist rápido
+
+1. Verificá servicios:
+
+```bash
+docker compose ps
+```
+
+2. Si `postgres` no está `Up`, levantalo:
+
+```bash
+docker compose up -d
+```
+
+3. Revisá logs:
+
+```bash
+docker compose logs --tail=100 postgres
+```
+
+4. Probá disponibilidad desde el contenedor:
+
+```bash
+docker compose exec -T postgres pg_isready -U finanzas -d finanzas_db
+```
+
+5. Reintentá en DBeaver con:
+   - Host: `localhost`
+   - Puerto: `5432`
+
+## Problemas comunes
+
+- **Connection refused**: contenedor apagado o puerto incorrecto.
+- **Password authentication failed**: revisar usuario/clave en `.env`.
+- **No se crean tablas**: si el volumen ya existía, el script de init no corre de nuevo. Ejecutar SQL manualmente o usar `./scripts/reset_bd.sh`.

--- a/finanzas-app/docs/modelo_datos.md
+++ b/finanzas-app/docs/modelo_datos.md
@@ -1,0 +1,23 @@
+# Modelo de datos v1
+
+## Objetivos
+
+- Multiusuario compartido por hogar.
+- Registro de ingresos, egresos y ahorro.
+- Cotización histórica USD/ARS por fuente.
+- Reportes en pesos (`monto_ars`) sin perder moneda original.
+
+## Reglas importantes
+
+1. Todo movimiento guarda moneda original y su equivalente en ARS.
+2. Si un movimiento está en ARS, `cotizacion_aplicada` puede quedar nula.
+3. Las etiquetas son dinámicas por hogar.
+4. Categorías simples (sin subcategorías en v1).
+5. Aumentos de gastos fijos solo manuales en v1.
+
+## Fuentes de cotización
+
+- Prioridad: AstroPay.
+- Fallback: MEP.
+
+Se guardan ambas si están disponibles para comparar comportamiento histórico.

--- a/finanzas-app/docs/resolver_conflictos_pr.md
+++ b/finanzas-app/docs/resolver_conflictos_pr.md
@@ -1,0 +1,49 @@
+# Resolver conflictos en tu PR (paso a paso)
+
+Cuando GitHub muestra **"This branch has conflicts"**, significa que tu rama y `main` tocaron los mismos archivos.
+
+## Opción recomendada (línea de comandos)
+
+### 1) Traer últimos cambios
+
+```bash
+git fetch origin
+```
+
+### 2) Ir a tu rama del PR
+
+```bash
+git checkout <tu-rama>
+```
+
+### 3) Mezclar `main` en tu rama
+
+```bash
+git merge origin/main
+```
+
+### 4) Resolver conflictos
+
+Abrí los archivos en conflicto y buscá bloques como:
+
+```text
+<<<<<<< HEAD
+...tu versión...
+=======
+...versión de main...
+>>>>>>> origin/main
+```
+
+Dejá el contenido correcto, borra esas marcas y guardá.
+
+### 5) Confirmar resolución
+
+```bash
+git add .
+git commit -m "Resuelve conflictos con main"
+git push
+```
+
+## Si usás GitHub Web
+
+También podés hacer click en **Resolve conflicts**, editar en web, y confirmar.

--- a/finanzas-app/frontend/.env.example
+++ b/finanzas-app/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/finanzas-app/frontend/index.html
+++ b/finanzas-app/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finanzas App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/finanzas-app/frontend/package.json
+++ b/finanzas-app/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "finanzas-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.4.1",
+    "vite": "^5.4.19"
+  }
+}

--- a/finanzas-app/frontend/src/App.jsx
+++ b/finanzas-app/frontend/src/App.jsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  createGastoFijo,
+  createCotizacion,
+  createMovimiento,
+  deleteMovimiento,
+  getCategorias,
+  getCotizaciones,
+  getGastosFijos,
+  getMovimientos,
+  getResumen,
+  updateMovimiento
+} from './services/api.js';
+import ResumenCards from './components/ResumenCards.jsx';
+import MovimientosTable from './components/MovimientosTable.jsx';
+import NuevoMovimientoForm from './components/NuevoMovimientoForm.jsx';
+import MenuLateral from './components/MenuLateral.jsx';
+import CotizacionesPanel from './components/CotizacionesPanel.jsx';
+import GastosFijosPanel from './components/GastosFijosPanel.jsx';
+
+export default function App() {
+  const [movimientos, setMovimientos] = useState([]);
+  const [categorias, setCategorias] = useState([]);
+  const [cotizaciones, setCotizaciones] = useState([]);
+  const [gastosFijos, setGastosFijos] = useState([]);
+  const [resumen, setResumen] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [openModal, setOpenModal] = useState(false);
+  const [modoModal, setModoModal] = useState('crear');
+  const [movimientoEditando, setMovimientoEditando] = useState(null);
+  const [menuCollapsed, setMenuCollapsed] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState(null);
+  const [seccionActiva, setSeccionActiva] = useState('dashboard');
+  const [mostrarEliminados, setMostrarEliminados] = useState(false);
+
+  const cargarDatos = async () => {
+    try {
+      setError('');
+      const [movData, catData, resumenData, cotiData, gastosData] = await Promise.all([
+        getMovimientos(1, mostrarEliminados),
+        getCategorias(1),
+        getResumen(1),
+        getCotizaciones(),
+        getGastosFijos(1)
+      ]);
+
+      setMovimientos(movData.items || []);
+      setCategorias(catData.items || []);
+      setResumen(resumenData || {});
+      setCotizaciones(cotiData.items || []);
+      setGastosFijos(gastosData.items || []);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  useEffect(() => {
+    cargarDatos();
+  }, [mostrarEliminados]);
+
+  const handleCrearMovimiento = async (payload) => {
+    try {
+      setLoading(true);
+      setError('');
+
+      if (modoModal === 'editar' && movimientoEditando) {
+        await updateMovimiento(movimientoEditando.id, {
+          descripcion: payload.descripcion,
+          categoria_id: payload.categoria_id,
+          cuenta_id: payload.cuenta_id
+        });
+      } else {
+        await createMovimiento(payload);
+      }
+
+      await cargarDatos();
+      setOpenModal(false);
+      setMovimientoEditando(null);
+      setModoModal('crear');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCrearGastoFijo = async (payload) => {
+    try {
+      setError('');
+      await createGastoFijo(payload);
+      await cargarDatos();
+      setSeccionActiva('gastos_fijos');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleCrearCotizacion = async (payload) => {
+    try {
+      setError('');
+      await createCotizacion(payload);
+      await cargarDatos();
+      setSeccionActiva('cotizacion');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleEditar = (movimiento) => {
+    setModoModal('editar');
+    setMovimientoEditando(movimiento);
+    setOpenModal(true);
+  };
+
+  const handleEliminar = async (id) => {
+    setDeleteTargetId(id);
+  };
+
+  const confirmarEliminar = async () => {
+    if (!deleteTargetId) return;
+
+    try {
+      setError('');
+      await deleteMovimiento(deleteTargetId);
+      await cargarDatos();
+      setDeleteTargetId(null);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const abrirModalCrear = () => {
+    setModoModal('crear');
+    setMovimientoEditando(null);
+    setOpenModal(true);
+  };
+
+  const ultimaActualizacion = useMemo(() => new Date().toLocaleString('es-AR'), [movimientos, resumen, cotizaciones, gastosFijos]);
+  const cicloActual = useMemo(
+    () =>
+      new Date().toLocaleDateString('es-AR', {
+        month: 'long',
+        year: 'numeric'
+      }),
+    []
+  );
+
+  return (
+    <main className={`container ${menuCollapsed ? 'menu-colapsado' : ''}`}>
+      <MenuLateral
+        collapsed={menuCollapsed}
+        onToggle={() => setMenuCollapsed((v) => !v)}
+        active={seccionActiva}
+        onSelect={setSeccionActiva}
+      />
+
+      <div className="contenido-principal">
+        <header className="hero">
+          <div>
+            <p className="eyebrow">Finanzas personales</p>
+            <h1>Panel mensual</h1>
+            <p className="subtitle">Controlá ingresos, egresos y ahorro sin depender de Excel.</p>
+          </div>
+          <div className="hero-meta">
+            <span className="pill">Hogar demo #1</span>
+            <span className="pill muted">Ciclo: {cicloActual}</span>
+            <span className="last-update">Actualizado: {ultimaActualizacion}</span>
+          </div>
+        </header>
+
+        {error && <p className="error">{error}</p>}
+
+        <ResumenCards resumen={resumen} />
+
+        <div className="contenido-dashboard">
+          {(seccionActiva === 'dashboard' || seccionActiva === 'movimientos') && (
+            <>
+              <section className="panel acciones-panel">
+                <h2>Movimientos</h2>
+                <p>Creá o editá movimientos desde un modal para mantener limpio el dashboard.</p>
+                <button type="button" onClick={abrirModalCrear}>
+                  + Nuevo movimiento
+                </button>
+                <label className="toggle-eliminados">
+                  <input
+                    type="checkbox"
+                    checked={mostrarEliminados}
+                    onChange={(e) => setMostrarEliminados(e.target.checked)}
+                  />
+                  Ver eliminados
+                </label>
+              </section>
+
+              <MovimientosTable movimientos={movimientos} onEditar={handleEditar} onEliminar={handleEliminar} />
+            </>
+          )}
+
+          {(seccionActiva === 'dashboard' || seccionActiva === 'cotizacion') && (
+            <CotizacionesPanel cotizaciones={cotizaciones} onCrear={handleCrearCotizacion} />
+          )}
+
+          {seccionActiva === 'gastos_fijos' && (
+            <GastosFijosPanel gastos={gastosFijos} categorias={categorias} onCrear={handleCrearGastoFijo} />
+          )}
+
+          {seccionActiva === 'ahorros' && (
+            <section className="panel">
+              <h2>🏦 Ahorros</h2>
+              <p>Próximo paso: vista dedicada para evolución de ahorro en ARS/USD.</p>
+            </section>
+          )}
+
+          {seccionActiva === 'reportes' && (
+            <section className="panel">
+              <h2>📊 Reportes</h2>
+              <p>Próximo paso: comparativas por mes, categoría y tendencia.</p>
+            </section>
+          )}
+        </div>
+      </div>
+
+      {openModal && (
+        <div className="modal-overlay" role="dialog" aria-modal="true">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h3>{modoModal === 'editar' ? 'Editar movimiento' : 'Alta de movimiento'}</h3>
+              <button
+                type="button"
+                className="close-btn"
+                onClick={() => {
+                  setOpenModal(false);
+                  setModoModal('crear');
+                  setMovimientoEditando(null);
+                }}
+              >
+                ✕
+              </button>
+            </div>
+            <NuevoMovimientoForm
+              categorias={categorias}
+              onCrear={handleCrearMovimiento}
+              loading={loading}
+              modo={modoModal}
+              initialValues={movimientoEditando}
+            />
+          </div>
+        </div>
+      )}
+
+      {deleteTargetId && (
+        <div className="modal-overlay" role="dialog" aria-modal="true">
+          <div className="modal-content confirm-modal">
+            <h3>🗑️ Confirmar eliminación</h3>
+            <p>¿Seguro querés eliminar este movimiento? Esta acción no se puede deshacer.</p>
+            <div className="confirm-actions">
+              <button type="button" className="btn-inline" onClick={() => setDeleteTargetId(null)}>
+                Cancelar
+              </button>
+              <button type="button" className="btn-inline danger" onClick={confirmarEliminar}>
+                Eliminar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/finanzas-app/frontend/src/components/CotizacionesPanel.jsx
+++ b/finanzas-app/frontend/src/components/CotizacionesPanel.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+
+export default function CotizacionesPanel({ cotizaciones, onCrear }) {
+  const [form, setForm] = useState({
+    fecha: new Date().toISOString().slice(0, 10),
+    fuente: 'mep',
+    compra: '',
+    venta: ''
+  });
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await onCrear({
+      fecha: form.fecha,
+      fuente: form.fuente,
+      compra: form.compra ? Number(form.compra) : null,
+      venta: Number(form.venta)
+    });
+  };
+
+  return (
+    <section className="panel cotizaciones-panel">
+      <div className="panel-header">
+        <h2>Cotización dólar</h2>
+        <p>Últimos valores por fuente cargada.</p>
+      </div>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Fecha
+          <input type="date" value={form.fecha} onChange={(e) => setForm((p) => ({ ...p, fecha: e.target.value }))} required />
+        </label>
+        <label>
+          Fuente
+          <input value={form.fuente} onChange={(e) => setForm((p) => ({ ...p, fuente: e.target.value }))} required />
+        </label>
+        <label>
+          Compra
+          <input type="number" value={form.compra} onChange={(e) => setForm((p) => ({ ...p, compra: e.target.value }))} />
+        </label>
+        <label>
+          Venta
+          <input type="number" value={form.venta} onChange={(e) => setForm((p) => ({ ...p, venta: e.target.value }))} required />
+        </label>
+        <button type="submit">Guardar cotización</button>
+      </form>
+
+      <div className="cotizaciones-grid">
+        {cotizaciones.map((coti) => (
+          <article key={`${coti.fuente}-${coti.fecha}`} className="cotizacion-item">
+            <h4>💱 {coti.fuente}</h4>
+            <p>Fecha: {coti.fecha}</p>
+            <p>Compra: {coti.compra ? `$${Number(coti.compra).toLocaleString('es-AR')}` : '-'}</p>
+            <p>Venta: ${Number(coti.venta || 0).toLocaleString('es-AR')}</p>
+          </article>
+        ))}
+        {cotizaciones.length === 0 && <p>No hay cotizaciones cargadas todavía.</p>}
+      </div>
+    </section>
+  );
+}

--- a/finanzas-app/frontend/src/components/GastosFijosPanel.jsx
+++ b/finanzas-app/frontend/src/components/GastosFijosPanel.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+
+export default function GastosFijosPanel({ gastos, categorias, onCrear }) {
+  const [form, setForm] = useState({
+    descripcion: '',
+    categoria_id: '',
+    moneda: 'ARS',
+    monto_base: '',
+    dia_vencimiento: ''
+  });
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await onCrear({
+      hogar_id: 1,
+      descripcion: form.descripcion,
+      categoria_id: Number(form.categoria_id),
+      moneda: form.moneda,
+      monto_base: Number(form.monto_base),
+      dia_vencimiento: form.dia_vencimiento ? Number(form.dia_vencimiento) : null
+    });
+
+    setForm({ descripcion: '', categoria_id: '', moneda: 'ARS', monto_base: '', dia_vencimiento: '' });
+  };
+
+  return (
+    <section className="panel">
+      <div className="panel-header">
+        <h2>📌 Gastos fijos</h2>
+        <p>Definí costos recurrentes para proyectar mejor tu mes.</p>
+      </div>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Descripción
+          <input value={form.descripcion} onChange={(e) => setForm((p) => ({ ...p, descripcion: e.target.value }))} required />
+        </label>
+
+        <label>
+          Categoría
+          <select value={form.categoria_id} onChange={(e) => setForm((p) => ({ ...p, categoria_id: e.target.value }))} required>
+            <option value="">Seleccionar</option>
+            {categorias.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.nombre}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Moneda
+          <select value={form.moneda} onChange={(e) => setForm((p) => ({ ...p, moneda: e.target.value }))}>
+            <option value="ARS">ARS</option>
+            <option value="USD">USD</option>
+          </select>
+        </label>
+
+        <label>
+          Monto base
+          <input type="number" min="1" value={form.monto_base} onChange={(e) => setForm((p) => ({ ...p, monto_base: e.target.value }))} required />
+        </label>
+
+        <label>
+          Día vencimiento
+          <input type="number" min="1" max="31" value={form.dia_vencimiento} onChange={(e) => setForm((p) => ({ ...p, dia_vencimiento: e.target.value }))} />
+        </label>
+
+        <button type="submit">Guardar gasto fijo</button>
+      </form>
+
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Descripción</th>
+              <th>Categoría</th>
+              <th>Moneda</th>
+              <th>Monto</th>
+              <th>Día</th>
+            </tr>
+          </thead>
+          <tbody>
+            {gastos.map((gasto) => (
+              <tr key={gasto.id}>
+                <td>{gasto.descripcion}</td>
+                <td>{gasto.categoria}</td>
+                <td>{gasto.moneda}</td>
+                <td>{Number(gasto.monto_base).toLocaleString('es-AR')}</td>
+                <td>{gasto.dia_vencimiento || '-'}</td>
+              </tr>
+            ))}
+            {gastos.length === 0 && (
+              <tr>
+                <td colSpan={5}>Todavía no hay gastos fijos.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/finanzas-app/frontend/src/components/MenuLateral.jsx
+++ b/finanzas-app/frontend/src/components/MenuLateral.jsx
@@ -1,0 +1,35 @@
+const items = [
+  { key: 'dashboard', label: 'Dashboard', icon: '🏠' },
+  { key: 'movimientos', label: 'Movimientos', icon: '💸' },
+  { key: 'gastos_fijos', label: 'Gastos fijos', icon: '📌' },
+  { key: 'cotizacion', label: 'Cotización dólar', icon: '💵' },
+  { key: 'ahorros', label: 'Ahorros', icon: '🏦' },
+  { key: 'reportes', label: 'Reportes', icon: '📊' }
+];
+
+export default function MenuLateral({ collapsed, onToggle, active, onSelect }) {
+  return (
+    <aside className={`menu-shell ${collapsed ? 'collapsed' : ''}`}>
+      <div className="menu-top">
+        <h3>{collapsed ? '☰' : 'Menú'}</h3>
+        <button type="button" className="toggle-menu" onClick={onToggle}>
+          {collapsed ? '»' : '«'}
+        </button>
+      </div>
+
+      <nav>
+        {items.map((item) => (
+          <button
+            key={item.key}
+            className={`menu-item ${active === item.key ? 'activo' : ''}`}
+            type="button"
+            title={item.label}
+            onClick={() => onSelect(item.key)}
+          >
+            {collapsed ? item.icon : `${item.icon} ${item.label}`}
+          </button>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/finanzas-app/frontend/src/components/MovimientosTable.jsx
+++ b/finanzas-app/frontend/src/components/MovimientosTable.jsx
@@ -1,0 +1,71 @@
+export default function MovimientosTable({ movimientos, onEditar, onEliminar }) {
+  return (
+    <section className="panel panel-table">
+      <div className="panel-header table-header">
+        <h2>Movimientos recientes</h2>
+        <span className="pill muted">{movimientos.length} registros</span>
+      </div>
+
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Fecha</th>
+              <th>Tipo</th>
+              <th>Categoría</th>
+              <th>Descripción</th>
+              <th>Monto ARS</th>
+              <th>Estado</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {movimientos.map((mov) => (
+              <tr key={mov.id}>
+                <td>{mov.fecha}</td>
+                <td>
+                  <span className={`badge badge-${mov.tipo_movimiento}`}>{mov.tipo_movimiento}</span>
+                </td>
+                <td>{mov.categoria || '-'}</td>
+                <td>{mov.descripcion || '-'}</td>
+                <td>${Number(mov.monto_ars).toLocaleString('es-AR')}</td>
+                <td>
+                  <span className={`badge ${mov.activo ? 'badge-activo' : 'badge-eliminado'}`}>
+                    {mov.activo ? 'Activo' : 'Eliminado'}
+                  </span>
+                </td>
+                <td>
+                  <div className="acciones-inline">
+                    <button
+                      type="button"
+                      className="btn-inline"
+                      title="Editar"
+                      disabled={!mov.activo}
+                      onClick={() => onEditar(mov)}
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-inline danger"
+                      title="Eliminar"
+                      disabled={!mov.activo}
+                      onClick={() => onEliminar(mov.id)}
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {movimientos.length === 0 && (
+              <tr>
+                <td colSpan={7}>Todavía no hay movimientos cargados.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/finanzas-app/frontend/src/components/NuevoMovimientoForm.jsx
+++ b/finanzas-app/frontend/src/components/NuevoMovimientoForm.jsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+
+const initialState = {
+  fecha: new Date().toISOString().slice(0, 10),
+  tipo_movimiento_id: 2,
+  categoria_id: '',
+  descripcion: '',
+  monto_ars: '',
+  moneda_original: 'ARS'
+};
+
+function normalizeInputDate(value) {
+  if (!value) return initialState.fecha;
+  if (value.includes('T')) return value.slice(0, 10);
+  if (value.includes('/')) {
+    const [day, month, year] = value.split('/');
+    if (day && month && year) return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+  }
+  return value;
+}
+
+export default function NuevoMovimientoForm({ categorias, onCrear, loading, modo = 'crear', initialValues = null }) {
+  const [form, setForm] = useState(initialState);
+
+  useEffect(() => {
+    if (!initialValues) {
+      setForm(initialState);
+      return;
+    }
+
+    setForm({
+      fecha: normalizeInputDate(initialValues.fecha),
+      tipo_movimiento_id:
+        initialValues.tipo_movimiento === 'ingreso'
+          ? 1
+          : initialValues.tipo_movimiento === 'ahorro'
+          ? 3
+          : 2,
+      categoria_id: initialValues.categoria_id || '',
+      descripcion: initialValues.descripcion || '',
+      monto_ars: Number(initialValues.monto_ars || 0),
+      moneda_original: initialState.moneda_original
+    });
+  }, [initialValues]);
+
+  const handleChange = (field, value) => setForm((prev) => ({ ...prev, [field]: value }));
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    await onCrear({
+      hogar_id: 1,
+      cuenta_id: 1,
+      tipo_movimiento_id: Number(form.tipo_movimiento_id),
+      categoria_id: form.categoria_id ? Number(form.categoria_id) : null,
+      fecha: form.fecha,
+      descripcion: form.descripcion,
+      moneda_original: form.moneda_original,
+      monto_original: Number(form.monto_ars),
+      monto_ars: Number(form.monto_ars),
+      creado_por_usuario_id: 1
+    });
+
+    if (modo === 'crear') {
+      setForm((prev) => ({ ...initialState, fecha: prev.fecha }));
+    }
+  };
+
+  return (
+    <section className="panel panel-form">
+      <div className="panel-header">
+        <h2>{modo === 'editar' ? 'Editar movimiento' : 'Cargar movimiento'}</h2>
+        <p>Completá los campos para registrar ingresos, egresos o ahorro.</p>
+      </div>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Fecha
+          <input type="date" value={form.fecha} onChange={(e) => handleChange('fecha', e.target.value)} required />
+        </label>
+
+        <label>
+          Tipo
+          <select value={form.tipo_movimiento_id} onChange={(e) => handleChange('tipo_movimiento_id', e.target.value)}>
+            <option value={1}>Ingreso</option>
+            <option value={2}>Egreso</option>
+            <option value={3}>Ahorro</option>
+          </select>
+        </label>
+
+        <label>
+          Categoría
+          <select value={form.categoria_id} onChange={(e) => handleChange('categoria_id', e.target.value)}>
+            <option value="">Sin categoría</option>
+            {categorias.map((categoria) => (
+              <option key={categoria.id} value={categoria.id}>
+                {categoria.nombre}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Monto ARS
+          <input
+            type="number"
+            min="1"
+            value={form.monto_ars}
+            onChange={(e) => handleChange('monto_ars', e.target.value)}
+            required
+          />
+        </label>
+
+        <label className="full-width">
+          Descripción
+          <input
+            type="text"
+            value={form.descripcion}
+            onChange={(e) => handleChange('descripcion', e.target.value)}
+            placeholder="Ej: Supermercado, sueldo, transferencia"
+          />
+        </label>
+
+        <button type="submit" disabled={loading}>
+          {loading ? 'Guardando...' : modo === 'editar' ? 'Guardar cambios' : 'Guardar movimiento'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/finanzas-app/frontend/src/components/ResumenCards.jsx
+++ b/finanzas-app/frontend/src/components/ResumenCards.jsx
@@ -1,0 +1,39 @@
+function FormattedAmount({ value }) {
+  return <strong>${Number(value || 0).toLocaleString('es-AR')}</strong>;
+}
+
+export default function ResumenCards({ resumen }) {
+  const { ingresos = 0, egresos = 0, ahorros = 0, balance = 0 } = resumen || {};
+
+  return (
+    <section className="cards-grid">
+      <article className="card card-income">
+        <h3>💚 Ingresos</h3>
+        <p>
+          <FormattedAmount value={ingresos} />
+        </p>
+      </article>
+
+      <article className="card card-expense">
+        <h3>🧾 Egresos</h3>
+        <p>
+          <FormattedAmount value={egresos} />
+        </p>
+      </article>
+
+      <article className="card card-saving">
+        <h3>🏦 Ahorro acumulado</h3>
+        <p>
+          <FormattedAmount value={ahorros} />
+        </p>
+      </article>
+
+      <article className="card card-balance">
+        <h3>⚖️ Balance</h3>
+        <p className={balance >= 0 ? 'positivo' : 'negativo'}>
+          <FormattedAmount value={balance} />
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/finanzas-app/frontend/src/main.jsx
+++ b/finanzas-app/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/finanzas-app/frontend/src/services/api.js
+++ b/finanzas-app/frontend/src/services/api.js
@@ -1,0 +1,153 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+function normalizeFetchError(error) {
+  if (error?.name === 'TypeError') {
+    return 'No se pudo conectar con la API. Verificá que backend esté levantado en http://localhost:3000 y reiniciá npm run dev.';
+  }
+  return error?.message || 'Ocurrió un error inesperado';
+}
+
+export async function getMovimientos(hogarId = 1, incluirEliminados = false) {
+  try {
+    const response = await fetch(`${API_URL}/movimientos?hogar_id=${hogarId}&incluir_eliminados=${incluirEliminados}`);
+    if (!response.ok) throw new Error('No se pudieron obtener movimientos');
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function getResumen(hogarId = 1) {
+  try {
+    const response = await fetch(`${API_URL}/dashboard/resumen?hogar_id=${hogarId}`);
+    if (!response.ok) throw new Error('No se pudo obtener resumen');
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function createMovimiento(payload) {
+  try {
+    const response = await fetch(`${API_URL}/movimientos`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      throw new Error(detail.error || 'No se pudo crear el movimiento');
+    }
+
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function updateMovimiento(id, payload) {
+  try {
+    const response = await fetch(`${API_URL}/movimientos/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      throw new Error(detail.error || 'No se pudo actualizar el movimiento');
+    }
+
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function deleteMovimiento(id) {
+  try {
+    const response = await fetch(`${API_URL}/movimientos/${id}`, {
+      method: 'DELETE'
+    });
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      throw new Error(detail.error || 'No se pudo eliminar el movimiento');
+    }
+
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function getCategorias(hogarId = 1) {
+  try {
+    const response = await fetch(`${API_URL}/categorias?hogar_id=${hogarId}`);
+    if (!response.ok) throw new Error('No se pudieron obtener categorías');
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function getCotizaciones(fecha) {
+  const url = fecha ? `${API_URL}/cotizaciones?fecha=${fecha}` : `${API_URL}/cotizaciones`;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error('No se pudieron obtener cotizaciones');
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function createCotizacion(payload) {
+  try {
+    const response = await fetch(`${API_URL}/cotizaciones`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      throw new Error(detail.error || 'No se pudo crear cotización');
+    }
+
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function getGastosFijos(hogarId = 1) {
+  try {
+    const response = await fetch(`${API_URL}/gastos-fijos?hogar_id=${hogarId}`);
+    if (!response.ok) throw new Error('No se pudieron obtener gastos fijos');
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}
+
+export async function createGastoFijo(payload) {
+  try {
+    const response = await fetch(`${API_URL}/gastos-fijos`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      throw new Error(detail.error || 'No se pudo crear el gasto fijo');
+    }
+
+    return response.json();
+  } catch (error) {
+    throw new Error(normalizeFetchError(error));
+  }
+}

--- a/finanzas-app/frontend/src/styles.css
+++ b/finanzas-app/frontend/src/styles.css
@@ -1,0 +1,143 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: #0f172a;
+  background: radial-gradient(circle at top right, #dbeafe 0%, transparent 40%), #eef2ff;
+}
+
+body { margin: 0; min-height: 100vh; }
+
+.container {
+  min-height: 100vh;
+  padding-left: 248px;
+  transition: padding-left 0.2s ease;
+}
+
+.container.menu-colapsado {
+  padding-left: 86px;
+}
+
+.contenido-principal { padding: 28px; max-width: 1200px; }
+
+.menu-shell {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 220px;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px;
+  border-right: 1px solid rgba(148, 163, 184, 0.25);
+  transition: width 0.2s ease;
+  z-index: 30;
+}
+
+.menu-shell.collapsed {
+  width: 58px;
+}
+
+.menu-top { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.menu-top h3 { margin: 0; }
+.toggle-menu { background: #1e293b; border: 1px solid #334155; color: #fff; border-radius: 8px; padding: 6px 8px; }
+
+.menu-shell nav { display: grid; gap: 8px; margin-top: 16px; }
+.menu-item {
+  text-align: left;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #334155;
+  background: #111827;
+  color: #e2e8f0;
+  cursor: pointer;
+}
+.menu-item.activo { background: #1d4ed8; border-color: #3b82f6; color: white; font-weight: 600; }
+
+.hero { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 20px; }
+.eyebrow { text-transform: uppercase; font-size: 12px; letter-spacing: 1.4px; color: #2563eb; margin: 0; }
+h1 { margin: 4px 0; font-size: 34px; }
+.subtitle { margin: 0; color: #475569; }
+.hero-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
+.last-update { font-size: 12px; color: #64748b; }
+
+.cards-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin: 20px 0; }
+.card, .panel {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.08);
+}
+.card h3 { margin: 0 0 10px; font-size: 14px; color: #475569; }
+.card p { margin: 0; font-size: 24px; }
+.card-income { border-left: 4px solid #16a34a; }
+.card-expense { border-left: 4px solid #ef4444; }
+.card-saving { border-left: 4px solid #0ea5e9; }
+.card-balance { border-left: 4px solid #7c3aed; }
+.positivo { color: #166534; }
+.negativo { color: #b91c1c; }
+.error { color: #b91c1c; font-weight: 600; background: #fee2e2; border: 1px solid #fecaca; border-radius: 10px; padding: 8px 12px; }
+
+.contenido-dashboard { display: grid; gap: 14px; }
+.acciones-panel { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.acciones-panel h2 { margin: 0; }
+.acciones-panel p { margin: 4px 0 0; color: #64748b; }
+.toggle-eliminados { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: #334155; }
+
+.panel-header h2 { margin: 0; }
+.panel-header p { margin: 6px 0 0; color: #64748b; font-size: 14px; }
+
+.form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-top: 14px; }
+label { display: flex; flex-direction: column; gap: 6px; font-size: 14px; }
+.full-width { grid-column: span 2; }
+input, select, button { padding: 10px; border: 1px solid #cbd5e1; border-radius: 10px; font-size: 14px; }
+button { background: #2563eb; color: white; cursor: pointer; border: none; font-weight: 600; }
+button:disabled { background: #94a3b8; }
+
+.table-wrapper { overflow-x: auto; margin-top: 12px; border-radius: 10px; }
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; border-bottom: 1px solid #e2e8f0; padding: 10px 6px; font-size: 14px; }
+tbody tr:hover { background: rgba(226, 232, 240, 0.35); }
+
+.acciones-inline { display: flex; gap: 6px; }
+.btn-inline { padding: 6px 8px; border-radius: 8px; font-size: 12px; }
+.acciones-inline .btn-inline { min-width: 34px; text-align: center; }
+.btn-inline.danger { background: #ef4444; }
+
+.pill { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border-radius: 999px; background: #dbeafe; color: #1e3a8a; font-size: 12px; font-weight: 600; }
+.pill.muted { background: #eef2ff; color: #4338ca; }
+.badge { display: inline-flex; padding: 2px 8px; border-radius: 999px; font-size: 12px; text-transform: capitalize; }
+.badge-ingreso { background: #dcfce7; color: #166534; }
+.badge-egreso { background: #fee2e2; color: #991b1b; }
+.badge-ahorro { background: #e0f2fe; color: #075985; }
+.badge-activo { background: #dcfce7; color: #166534; }
+.badge-eliminado { background: #fee2e2; color: #991b1b; }
+
+.cotizaciones-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-top: 10px; }
+.cotizacion-item { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 10px; padding: 10px; }
+.cotizacion-item h4 { margin: 0 0 4px; }
+.cotizacion-item p { margin: 4px 0; font-size: 14px; }
+
+.modal-overlay { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.6); display: flex; align-items: center; justify-content: center; padding: 20px; z-index: 100; }
+.modal-content { width: min(760px, 100%); background: #fff; border-radius: 14px; padding: 16px; box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25); }
+.modal-header { display: flex; justify-content: space-between; align-items: center; gap: 10px; margin-bottom: 6px; }
+.close-btn { background: #e2e8f0; color: #0f172a; width: 34px; height: 34px; border-radius: 8px; }
+.confirm-modal p { color: #475569; }
+.confirm-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
+
+@media (max-width: 980px) {
+  .container,
+  .container.menu-colapsado { padding-left: 0; }
+  .menu-shell,
+  .menu-shell.collapsed { position: static; width: auto; margin: 12px; border-radius: 12px; }
+  .contenido-principal { padding: 12px; }
+  .cards-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .cotizaciones-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 640px) {
+  .hero { flex-direction: column; }
+  .hero-meta { align-items: flex-start; }
+  .cards-grid, .form-grid, .cotizaciones-grid { grid-template-columns: 1fr; }
+  .full-width { grid-column: span 1; }
+  .acciones-panel { flex-direction: column; align-items: flex-start; }
+}

--- a/finanzas-app/frontend/vite.config.js
+++ b/finanzas-app/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/finanzas-app/scripts/estado_entorno.ps1
+++ b/finanzas-app/scripts/estado_entorno.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location (Join-Path $PSScriptRoot '..')
+
+docker compose ps
+
+Write-Host "`n--- Últimos logs de postgres ---"
+docker compose logs --tail=80 postgres

--- a/finanzas-app/scripts/estado_entorno.sh
+++ b/finanzas-app/scripts/estado_entorno.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+docker compose ps
+
+echo "\n--- Últimos logs de postgres ---"
+docker compose logs --tail=80 postgres

--- a/finanzas-app/scripts/iniciar_entorno.ps1
+++ b/finanzas-app/scripts/iniciar_entorno.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location (Join-Path $PSScriptRoot '..')
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+  Write-Error 'Docker no está instalado o no está en PATH.'
+}
+
+if (-not (Test-Path '.env')) {
+  Copy-Item '.env.example' '.env'
+  Write-Host 'Se creó .env desde .env.example'
+}
+
+Write-Host '[1/4] Levantando PostgreSQL...'
+docker compose up -d
+
+Write-Host '[2/4] Esperando healthcheck...'
+for ($i = 0; $i -lt 30; $i++) {
+  $estado = docker inspect --format='{{json .State.Health.Status}}' finanzas_postgres 2>$null
+  if ($estado -match 'healthy') { break }
+  Start-Sleep -Seconds 2
+}
+
+Write-Host '[3/4] Estado de servicios...'
+docker compose ps
+
+Write-Host '[4/4] Verificando DB...'
+docker compose exec -T postgres pg_isready -U finanzas -d finanzas_db
+
+Write-Host 'Entorno listo.'
+Write-Host 'DBeaver => Host: localhost | Puerto: 5432 | DB: finanzas_db | User: finanzas'

--- a/finanzas-app/scripts/iniciar_entorno.sh
+++ b/finanzas-app/scripts/iniciar_entorno.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "❌ Docker no está instalado o no está en PATH."
+  exit 1
+fi
+
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "ℹ️  Se creó .env desde .env.example"
+fi
+
+echo "[1/4] Levantando PostgreSQL..."
+docker compose up -d
+
+echo "[2/4] Esperando que PostgreSQL esté saludable..."
+for _ in $(seq 1 30); do
+  estado=$(docker inspect --format='{{json .State.Health.Status}}' finanzas_postgres 2>/dev/null | tr -d '"' || true)
+  if [ "$estado" = "healthy" ]; then
+    break
+  fi
+  sleep 2
+done
+
+echo "[3/4] Estado actual de servicios"
+docker compose ps
+
+echo "[4/4] Verificando conexión a la DB"
+docker compose exec -T postgres pg_isready -U "${POSTGRES_USER:-finanzas}" -d "${POSTGRES_DB:-finanzas_db}"
+
+echo "✅ Entorno listo"
+echo "🔌 DBeaver => Host: ${POSTGRES_HOST:-localhost} | Puerto: ${POSTGRES_PORT:-5432} | DB: ${POSTGRES_DB:-finanzas_db} | User: ${POSTGRES_USER:-finanzas}"

--- a/finanzas-app/scripts/reset_bd.ps1
+++ b/finanzas-app/scripts/reset_bd.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location (Join-Path $PSScriptRoot '..')
+
+Write-Host '[1/3] Deteniendo servicios...'
+docker compose down
+
+Write-Host '[2/3] Eliminando volumen postgres_data...'
+docker volume rm finanzas-app_postgres_data | Out-Null
+
+Write-Host '[3/3] Iniciando PostgreSQL limpio...'
+docker compose up -d
+
+Write-Host 'Base reiniciada.'

--- a/finanzas-app/scripts/reset_bd.sh
+++ b/finanzas-app/scripts/reset_bd.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resetea la base local eliminando volumen y recreando contenedor.
+# ADVERTENCIA: borra todos los datos locales de PostgreSQL.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+echo "[1/3] Deteniendo servicios..."
+docker compose down
+
+echo "[2/3] Eliminando volumen postgres_data..."
+docker volume rm finanzas-app_postgres_data >/dev/null 2>&1 || true
+
+echo "[3/3] Iniciando PostgreSQL limpio..."
+docker compose up -d
+
+echo "Base reiniciada. El esquema se aplica automáticamente al primer arranque."


### PR DESCRIPTION
### Motivation

- Crear la base inicial del proyecto "finanzas-app" con backend mínimo, frontend demo y esquema de base de datos para empezar el desarrollo local.
- Proveer scripts e `docker-compose` para levantar PostgreSQL rápidamente y facilitar pruebas locales con datos demo.
- Exponer endpoints básicos para movimientos, categorías, etiquetas, cotizaciones, gastos fijos y un resumen de dashboard para integrar con el frontend.
- Documentar el flujo de arranque, conexión (DBeaver) y resolución de conflictos para colaboradores.

### Description

- Agregado el servicio completo `finanzas-app/` con archivos de infraestructura y ejemplos de entorno: `docker-compose.yml`, `.env.example`, y scripts en `scripts/` (`iniciar_entorno.sh`, `reset_bd.sh`, y sus versiones PowerShell`).
- Añadido esquema SQL inicial y datos demo en `bd/` (`01_esquema_inicial.sql`, `02_datos_demo.sql`, `03_movimientos_soft_delete.sql`).
- Implementado backend mínimo en `backend/` con `express` y `pg`, incluyendo `src/main.js` que expone endpoints como `GET /salud`, `GET|POST|PATCH|DELETE /movimientos`, `GET|POST /categorias`, `GET|POST /etiquetas`, `GET /dashboard/resumen`, `GET|POST /cotizaciones`, y `GET|POST /gastos-fijos`.
- Añadido frontend demo en `frontend/` con React + Vite, componentes principales y consumo de la API en `frontend/src/services/api.js`, además de estilos y configuración de `vite`.
- Incluida documentación y guías en `README.md` y `docs/` (`api_v1.md`, `modelo_datos.md`, `conexion_dbeaver.md`, `resolver_conflictos_pr.md`).

### Testing

- No se añadieron ni ejecutaron pruebas automatizadas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacd15207c83288b2f7048cd9541c9)